### PR TITLE
[POOP-119] 견종 정보 등록/수정 기능 및 팝업 개선

### DIFF
--- a/apis/index.ts
+++ b/apis/index.ts
@@ -80,6 +80,23 @@ export const uploadGraphic = async (formData: FormData) => {
   }
 };
 
+export const updateBreed = async (formData: FormData) => {
+  try {
+    const {
+      result: { resultCode },
+      body,
+    } = await POST(`/breeds`, formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+
+    return resultCode < 500 ? body : null;
+  } catch (error) {
+    console.error(error);
+    throw new Error('Failed to update breeds');
+  }
+};
 export const updateGraphic = async (formData: FormData) => {
   try {
     const {

--- a/apis/index.ts
+++ b/apis/index.ts
@@ -1,8 +1,10 @@
 import { GET, PUT, POST, DELETE } from '@/server/axios';
-import type { Breed, Graphic, GraphicParams } from '@/types';
+import type { Breed, GetBreedsQuery, Graphic, GraphicParams } from '@/types';
 
 // 변환 함수 정의
-const toRecord = (params?: GraphicParams): Record<string, string> => {
+const toRecord = (
+  params?: GraphicParams | GetBreedsQuery,
+): Record<string, string> => {
   const result: Record<string, string> = {};
   if (params) {
     for (const key in params) {
@@ -14,12 +16,13 @@ const toRecord = (params?: GraphicParams): Record<string, string> => {
   return result;
 };
 
-export const getBreeds = async () => {
+export const getBreeds = async (query?: GetBreedsQuery) => {
+  const queryStr = query ? new URLSearchParams(toRecord(query)).toString() : '';
   try {
     const {
       result: { resultCode },
       body,
-    } = await GET<Breed[]>('/breeds');
+    } = await GET<Breed[]>(`/breeds?${queryStr}`);
     return resultCode < 500 ? body : [];
   } catch (error) {
     console.error(error);

--- a/apis/index.ts
+++ b/apis/index.ts
@@ -115,7 +115,21 @@ export const updateGraphic = async (formData: FormData) => {
   }
 };
 
-export const deleteGraphic = async (ids: string[]) => {
+export const deleteBreeds = async (ids: string[]) => {
+  try {
+    const {
+      result: { resultCode },
+      body,
+    } = await DELETE(`/breeds`, { ids });
+
+    return resultCode < 500 ? body : null;
+  } catch (error) {
+    console.error(error);
+    throw new Error('Failed to delete breeds');
+  }
+};
+
+export const deleteGraphics = async (ids: string[]) => {
   try {
     const {
       result: { resultCode },

--- a/apis/index.ts
+++ b/apis/index.ts
@@ -1,14 +1,18 @@
 import { GET, PUT, POST, DELETE } from '@/server/axios';
-import type { Breed, GetBreedsQuery, Graphic, GraphicParams } from '@/types';
+import type { Breed, GetBreedsParams, Graphic, GraphicParams } from '@/types';
 
-// 변환 함수 정의
+// parameter -> query 변환 함수 정의
 const toRecord = (
-  params?: GraphicParams | GetBreedsQuery,
+  params?: GraphicParams | GetBreedsParams,
 ): Record<string, string> => {
   const result: Record<string, string> = {};
   if (params) {
     for (const key in params) {
-      if (params[key] !== undefined && params[key] !== null) {
+      if (
+        params[key] !== undefined &&
+        params[key] !== null &&
+        params[key] !== ''
+      ) {
         result[key] = params[key] as string;
       }
     }
@@ -16,7 +20,7 @@ const toRecord = (
   return result;
 };
 
-export const getBreeds = async (query?: GetBreedsQuery) => {
+export const getBreeds = async (query?: GetBreedsParams) => {
   const queryStr = query ? new URLSearchParams(toRecord(query)).toString() : '';
   try {
     const {
@@ -38,7 +42,7 @@ export const getGraphics = async (params?: GraphicParams) => {
     const {
       result: { resultCode },
       body,
-    } = await GET<Graphic[]>(`/graphics?${queryStr}`);
+    } = await GET<Graphic[]>(`/graphics${queryStr && '?' + queryStr}`);
 
     return resultCode < 500 ? body : [];
   } catch (error) {

--- a/apis/index.ts
+++ b/apis/index.ts
@@ -1,5 +1,5 @@
 import { GET, PUT, POST, DELETE } from '@/server/axios';
-import type { BreedList, Graphic, GraphicParams } from '@/types';
+import type { Breed, Graphic, GraphicParams } from '@/types';
 
 // 변환 함수 정의
 const toRecord = (params?: GraphicParams): Record<string, string> => {
@@ -16,8 +16,11 @@ const toRecord = (params?: GraphicParams): Record<string, string> => {
 
 export const getBreeds = async () => {
   try {
-    const response = await GET<BreedList>('/breeds');
-    return response;
+    const {
+      result: { resultCode },
+      body,
+    } = await GET<Breed[]>('/breeds');
+    return resultCode < 500 ? body : [];
   } catch (error) {
     console.error(error);
     throw new Error('Failed to get breeds');
@@ -41,6 +44,24 @@ export const getGraphics = async (params?: GraphicParams) => {
   }
 };
 
+export const uploadBreed = async (formData: FormData) => {
+  try {
+    const {
+      result: { resultCode },
+      body,
+    } = await PUT(`/breeds`, formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+
+    return resultCode < 500 ? body : null;
+  } catch (error) {
+    console.error(error);
+    throw new Error('Failed to upload breeds');
+  }
+};
+
 export const uploadGraphic = async (formData: FormData) => {
   try {
     const {
@@ -48,7 +69,7 @@ export const uploadGraphic = async (formData: FormData) => {
       body,
     } = await PUT(`/graphics`, formData, {
       headers: {
-        'Content-Type': 'multipart/form-data', // 요청 특정 헤더 설정
+        'Content-Type': 'multipart/form-data',
       },
     });
 

--- a/app/resource/page.tsx
+++ b/app/resource/page.tsx
@@ -1,23 +1,19 @@
-import { getBreeds } from '@/apis';
-import { Dogs } from '@/components/resource/dogs';
+import { Breeds } from '@/components/resource/dogs';
 import { Graphics } from '@/components/resource/graphics';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import React from 'react';
 
-const DogsPage = async () => {
-  const breeds = await getBreeds();
-  const breedList = Object.values(breeds ?? {}).flat();
-
+const DogsPage = () => {
   return (
     <div className="flex h-full flex-col">
       <div className="flex-1 space-y-4 p-8 pt-6">
-        <Tabs defaultValue="graphics" className="space-y-4">
+        <Tabs defaultValue="dogs" className="space-y-4">
           <TabsList>
             <TabsTrigger value="dogs">Dogs</TabsTrigger>
             <TabsTrigger value="graphics">Graphics</TabsTrigger>
           </TabsList>
           <TabsContent value="dogs" className="space-y-4">
-            <Dogs data={breedList} />
+            <Breeds />
           </TabsContent>
           <TabsContent value="graphics" className="space-y-4">
             <Graphics />

--- a/app/resource/page.tsx
+++ b/app/resource/page.tsx
@@ -6,11 +6,15 @@ import React from 'react';
 const DogsPage = () => {
   return (
     <div className="flex h-full flex-col">
-      <div className="flex-1 space-y-4 p-8 pt-6">
-        <Tabs defaultValue="dogs" className="space-y-4">
-          <TabsList>
-            <TabsTrigger value="dogs">Dogs</TabsTrigger>
-            <TabsTrigger value="graphics">Graphics</TabsTrigger>
+      <div className="flex-1 space-y-4 p-8 pt-24">
+        <Tabs defaultValue="dogs" className="space-y-16">
+          <TabsList tabType="menu">
+            <TabsTrigger tabType="menu" value="dogs">
+              Dogs
+            </TabsTrigger>
+            <TabsTrigger tabType="menu" value="graphics">
+              Graphics
+            </TabsTrigger>
           </TabsList>
           <TabsContent value="dogs" className="space-y-4">
             <Breeds />

--- a/components/common/loading.tsx
+++ b/components/common/loading.tsx
@@ -1,11 +1,18 @@
-"use client"
+'use client';
 
-import { ClipLoader } from "react-spinners"
+import { ClipLoader } from 'react-spinners';
 
-export const Loading = () => {
-    return (
-        <div className="flex h-full w-full items-center justify-center">
-            <ClipLoader color="foreground" size={50} />
-        </div>
-    )
+interface LoadingProps {
+  size?: number;
 }
+export const Loading = ({ size }: LoadingProps) => {
+  return (
+    <div className="flex h-7 w-7 items-center justify-center">
+      <ClipLoader color="foreground" size={size || 24} />
+    </div>
+
+    //     <div className="flex h-full w-full items-center justify-center">
+    //     <ClipLoader color="foreground" size={50} />
+    //   </div>
+  );
+};

--- a/components/resource/breed-info.tsx
+++ b/components/resource/breed-info.tsx
@@ -1,0 +1,47 @@
+import type { Table } from '@tanstack/react-table';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useContext } from 'react';
+import { BreedContext } from './dogs';
+interface BreedInfoProps<TData> {
+  table: Table<TData>;
+}
+
+export function BreedInfo<TData>({ table }: BreedInfoProps<TData>) {
+  const totalCount = table.getRowCount();
+
+  const breedContext = useContext(BreedContext);
+  const handleGetBreeds = breedContext?.handleGetBreeds;
+
+  const handleValueChange = async (value: string) => {
+    console.log('선택된 값:', value); // 선택된 값을 콘솔에 출력
+
+    if (handleGetBreeds) {
+      const query = {};
+      // TODO: 정렬 기능 추가 필요
+      await handleGetBreeds(query);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-8">
+      <p className="text-2xl">총 {totalCount}마리</p>
+      <Select defaultValue="apple" onValueChange={handleValueChange}>
+        <SelectTrigger className="w-[150px] bg-custom-gray-500 rounded-2xl ">
+          <SelectValue placeholder="정렬 기준 선택" />
+        </SelectTrigger>
+        <SelectContent className="bg-custom-gray-400 rounded-2xl p-0">
+          <SelectItem value="recent">최근 등록 순</SelectItem>
+          <SelectItem value="oldest">오래된 순</SelectItem>
+          <SelectItem value="korean-alphabet">가나다 순</SelectItem>
+          <SelectItem value="alphabetical">알파벳 순</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/components/resource/breed-info.tsx
+++ b/components/resource/breed-info.tsx
@@ -31,11 +31,11 @@ export function BreedInfo<TData>({ table }: BreedInfoProps<TData>) {
   return (
     <div className="flex items-center gap-8">
       <p className="text-2xl">총 {totalCount}마리</p>
-      <Select defaultValue="apple" onValueChange={handleValueChange}>
-        <SelectTrigger className="w-[150px] bg-custom-gray-500 rounded-2xl ">
+      <Select defaultValue="recent" onValueChange={handleValueChange}>
+        <SelectTrigger className="w-[150px] h-[45px] bg-custom-gray-500 rounded-2xl">
           <SelectValue placeholder="정렬 기준 선택" />
         </SelectTrigger>
-        <SelectContent className="bg-custom-gray-400 rounded-2xl p-0">
+        <SelectContent className="bg-custom-gray-400 rounded-2xl ">
           <SelectItem value="recent">최근 등록 순</SelectItem>
           <SelectItem value="oldest">오래된 순</SelectItem>
           <SelectItem value="korean-alphabet">가나다 순</SelectItem>

--- a/components/resource/breed-update.tsx
+++ b/components/resource/breed-update.tsx
@@ -1,0 +1,156 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { BreedUpdateSchema } from '@/lib/validators';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { type z } from 'zod';
+import { updateBreed } from '@/apis';
+import { useState } from 'react';
+import type { BreedFieldErrors, BreedData } from '@/types';
+import Image from 'next/image';
+import { toast } from 'react-hot-toast';
+import { Button } from '../ui/button';
+
+interface BreedUpdateProps<TData> {
+  selectedItem: TData | undefined;
+  onEditComplete: () => void;
+}
+
+export function BreedUpdate<TData extends BreedData>({
+  selectedItem,
+  onEditComplete,
+}: BreedUpdateProps<TData>) {
+  const [errors, setErrors] = useState<BreedFieldErrors>();
+
+  const form = useForm<z.infer<typeof BreedUpdateSchema>>({
+    resolver: zodResolver(BreedUpdateSchema),
+  });
+
+  const handleEdit = (formData: FormData) => {
+    if (selectedItem) {
+      const data = {
+        category: formData.get('category'),
+      };
+
+      const result = BreedUpdateSchema.safeParse(data);
+
+      if (!result.success) {
+        setErrors(result.error.flatten().fieldErrors);
+      } else {
+        try {
+          formData.append('id', selectedItem.id);
+          if (!formData.get('name')) formData.delete('name');
+          void toast.promise(updateBreed(formData), {
+            loading: '수정 중입니다.',
+            success: <b>수정되었습니다!</b>,
+            error: <b>견종 정보 수정에 실패하였습니다.</b>,
+          });
+          onEditComplete(); // 수정 완료 후 콜백 호출
+        } catch (error) {
+          console.error('견종 정보 수정 실패 ', error);
+        }
+      }
+    }
+  };
+
+  return (
+    <>
+      <p className="text-4xl mb-12">{selectedItem?.nameKR}</p>
+      <Form {...form}>
+        <form
+          action={handleEdit}
+          className="flex flex-col w-full space-y-4 gap-1 px-1"
+        >
+          {/* 이미지 */}
+          <FormField
+            name="file"
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            render={({ field: { value, onChange, ...fieldProps } }) => (
+              <FormItem>
+                <FormLabel>
+                  <Image
+                    width={100}
+                    height={100}
+                    src={selectedItem?.avatar || ''}
+                    alt={selectedItem?.nameKR || ''}
+                    unoptimized
+                  />
+                </FormLabel>
+
+                <FormControl>
+                  <Input
+                    {...fieldProps}
+                    className="hidden"
+                    type="file"
+                    accept=".jpg,.png"
+                    onChange={(event) => {
+                      const file = event.target.files && event.target.files[0];
+                      onChange(file);
+                    }}
+                  />
+                </FormControl>
+
+                <FormMessage>{errors?.file}</FormMessage>
+              </FormItem>
+            )}
+          />
+
+          {/* 국문 이름 */}
+          <FormField
+            control={form.control}
+            name="nameKR"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>국문 이름</FormLabel>
+                <div className="flex flex-col gap-2">
+                  <FormControl>
+                    <Input
+                      placeholder={selectedItem?.nameKR}
+                      {...field}
+                      value={field.value || ''}
+                    />
+                  </FormControl>
+
+                  <FormMessage>{errors?.nameKR}</FormMessage>
+                </div>
+              </FormItem>
+            )}
+          />
+
+          {/* 영문문 이름 */}
+          <FormField
+            control={form.control}
+            name="nameEN"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>영문 이름</FormLabel>
+                <div className="flex flex-col gap-2">
+                  <FormControl>
+                    <Input
+                      placeholder={selectedItem?.nameEN}
+                      {...field}
+                      value={field.value || ''}
+                    />
+                  </FormControl>
+
+                  <FormMessage>{errors?.nameEN}</FormMessage>
+                </div>
+              </FormItem>
+            )}
+          />
+
+          <Button className="!mt-8 ml-auto" type="submit">
+            수정
+          </Button>
+        </form>
+      </Form>
+    </>
+  );
+}

--- a/components/resource/breed-upload-popup.tsx
+++ b/components/resource/breed-upload-popup.tsx
@@ -14,18 +14,18 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from '../ui/carousel';
-import { GraphicUpload } from './graphic-upload';
 import { Plus } from 'lucide-react';
+import { BreedUpload } from './breed-upload';
 
-interface GraphicUploadPopupProps {
+interface BreedUploadPopupProps {
   onOpenChange: (isOpen: boolean) => void;
   isOpen: boolean;
 }
 
-export function GraphicUploadPopup({
+export function BreedUploadPopup({
   isOpen,
   onOpenChange,
-}: GraphicUploadPopupProps) {
+}: BreedUploadPopupProps) {
   const [uploadList, setUploadList] = useState<FormData[]>([]);
   const [carouselList, setCarouselList] = useState<FormData[]>([]);
   const carouselNextRef = useRef<HTMLButtonElement>(null);
@@ -63,13 +63,13 @@ export function GraphicUploadPopup({
       </DialogTrigger>
       <DialogContent className="sm:max-w-[550px]">
         <DialogHeader className="mb-6">
-          <DialogTitle>그래픽 추가</DialogTitle>
+          <DialogTitle>견종 추가</DialogTitle>
         </DialogHeader>
         <Carousel className="w-full">
           <CarouselContent>
             {carouselList.map((item, idx) => (
               <CarouselItem key={idx}>
-                <GraphicUpload
+                <BreedUpload
                   isOpen={isOpen}
                   onOpenChange={onOpenChange}
                   uploadList={uploadList}

--- a/components/resource/dogs.tsx
+++ b/components/resource/dogs.tsx
@@ -2,7 +2,7 @@
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { DataTable } from '@/components/ui/data-table/data-table';
-import type { Breed, BreedContextType, GetBreedsQuery } from '@/types';
+import type { Breed, BreedContextType, GetBreedsParams } from '@/types';
 import type { ColumnDef } from '@tanstack/react-table';
 import { DataTableColumnHeader } from '../ui/data-table/data-table-column-header';
 import { createContext, useEffect, useState } from 'react';
@@ -16,8 +16,8 @@ export const BreedContext = createContext<BreedContextType | undefined>(
 export const Breeds = () => {
   const [breeds, setBreeds] = useState<Breed[]>([]);
 
-  const handleGetBreeds = async (query?: GetBreedsQuery) => {
-    const defaultQuery: GetBreedsQuery = {
+  const handleGetBreeds = async (query?: GetBreedsParams) => {
+    const defaultQuery: GetBreedsParams = {
       orderKey: 'createdAt',
       direction: 'desc',
       // cursor: '',

--- a/components/resource/dogs.tsx
+++ b/components/resource/dogs.tsx
@@ -8,7 +8,6 @@ import { DataTableColumnHeader } from '../ui/data-table/data-table-column-header
 import { createContext, useEffect, useState } from 'react';
 import { getBreeds } from '@/apis';
 import { Checkbox } from '../ui/checkbox';
-import LottieAnimation from './lottie-animation';
 
 export const BreedContext = createContext<BreedContextType | undefined>(
   undefined,
@@ -34,20 +33,15 @@ export const Breeds = () => {
     {
       accessorKey: 'avatar',
       header: '사진',
-      cell: ({ row }) => {
-        const type = row.getValue('type');
-        return type === 'GIF' ? (
-          <Avatar className="h-9 w-9">
-            <AvatarImage
-              src={row.getValue('avatar')}
-              alt={row.getValue('nameKR')}
-            />
-            <AvatarFallback>{row.getValue('nameKR')}</AvatarFallback>
-          </Avatar>
-        ) : type === 'Lottie' ? (
-          <LottieAnimation url={row.getValue('avatar')} />
-        ) : null;
-      },
+      cell: ({ row }) => (
+        <Avatar className="h-9 w-9">
+          <AvatarImage
+            src={row.getValue('avatar')}
+            alt={row.getValue('nameKR')}
+          />
+          <AvatarFallback>{row.getValue('nameKR')}</AvatarFallback>
+        </Avatar>
+      ),
     },
     {
       accessorKey: 'nameKR',

--- a/components/resource/dogs.tsx
+++ b/components/resource/dogs.tsx
@@ -2,7 +2,7 @@
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { DataTable } from '@/components/ui/data-table/data-table';
-import type { Breed, BreedContextType } from '@/types';
+import type { Breed, BreedContextType, GetBreedsQuery } from '@/types';
 import type { ColumnDef } from '@tanstack/react-table';
 import { DataTableColumnHeader } from '../ui/data-table/data-table-column-header';
 import { createContext, useEffect, useState } from 'react';
@@ -16,8 +16,19 @@ export const BreedContext = createContext<BreedContextType | undefined>(
 export const Breeds = () => {
   const [breeds, setBreeds] = useState<Breed[]>([]);
 
-  const handleGetBreeds = async () => {
-    const breeds = await getBreeds();
+  const handleGetBreeds = async (query?: GetBreedsQuery) => {
+    const defaultQuery: GetBreedsQuery = {
+      orderKey: 'createdAt',
+      direction: 'desc',
+      // cursor: '',
+    };
+
+    const effectiveQuery = {
+      ...defaultQuery,
+      ...query,
+    };
+
+    const breeds = await getBreeds(effectiveQuery);
     setBreeds(breeds);
   };
 

--- a/components/resource/dogs.tsx
+++ b/components/resource/dogs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Avatar, AvatarImage } from '@/components/ui/avatar';
 import { DataTable } from '@/components/ui/data-table/data-table';
 import type { Breed, BreedContextType, GetBreedsParams } from '@/types';
 import type { ColumnDef } from '@tanstack/react-table';
@@ -8,6 +8,7 @@ import { DataTableColumnHeader } from '../ui/data-table/data-table-column-header
 import { createContext, useEffect, useState } from 'react';
 import { getBreeds } from '@/apis';
 import { Checkbox } from '../ui/checkbox';
+import { Loading } from '../common/loading';
 
 export const BreedContext = createContext<BreedContextType | undefined>(
   undefined,
@@ -50,7 +51,7 @@ export const Breeds = () => {
             src={row.getValue('avatar')}
             alt={row.getValue('nameKR')}
           />
-          <AvatarFallback>{row.getValue('nameKR')}</AvatarFallback>
+          <Loading />
         </Avatar>
       ),
     },

--- a/components/resource/graphic-info.tsx
+++ b/components/resource/graphic-info.tsx
@@ -10,42 +10,48 @@ import { GraphicRadioGroup } from './graphic-radio-group';
 import { GraphicContext } from './graphics';
 
 export function GraphicInfo() {
-  const [format, setFormat] = useState('all');
-  const [order, setOrder] = useState('recent');
-  const graphicContext = useContext(GraphicContext);
-  const handleGetGraphics = graphicContext?.handleGetGraphics;
+  const [formatVal, setFormatVal] = useState('GIF');
+  const [orderVal, setOrderVal] = useState('DESC');
+  const { setOrder, setFormat } = useContext(GraphicContext)!;
 
   const handleValueChange = useCallback(() => {
-    console.log('선택된 값:', order, format); // 선택된 값을 콘솔에 출력
-
-    if (handleGetGraphics) {
-      // const query = {};
-      // TODO: 정렬 기능 추가 필요
-      // await handleGetGraphics(query);
+    if (setOrder && setFormat) {
+      setOrder(orderVal);
+      setFormat(formatVal === 'all' ? '' : formatVal);
     }
-  }, [order, format, handleGetGraphics]);
+  }, [orderVal, formatVal, setOrder, setFormat]);
 
   useEffect(() => {
     void handleValueChange();
-  }, [order, format, handleValueChange]);
+  }, [orderVal, formatVal, handleValueChange]);
 
   return (
     <div className="flex items-center gap-8">
       <GraphicRadioGroup />
       <div className="flex gap-2">
-        <Select defaultValue="recent" onValueChange={setOrder}>
+        <Select defaultValue="DESC" onValueChange={setOrderVal}>
           <SelectTrigger className="w-[150px] h-[45px] bg-custom-gray-500 rounded-2xl">
             <SelectValue placeholder="정렬 기준 선택" />
           </SelectTrigger>
           <SelectContent className="bg-custom-gray-400 rounded-2xl ">
-            <SelectItem value="recent">최근 등록 순</SelectItem>
-            <SelectItem value="oldest">오래된 순</SelectItem>
-            <SelectItem value="korean-alphabet">가나다 순</SelectItem>
-            <SelectItem value="alphabetical">알파벳 순</SelectItem>
+            <SelectItem value="DESC">내림차순</SelectItem>
+            <SelectItem value="ASC">올림차순</SelectItem>
+            <SelectItem disabled value="recent">
+              최근 등록 순
+            </SelectItem>
+            <SelectItem disabled value="oldest">
+              오래된 순
+            </SelectItem>
+            <SelectItem disabled value="korean-alphabet">
+              가나다 순
+            </SelectItem>
+            <SelectItem disabled value="alphabetical">
+              알파벳 순
+            </SelectItem>
           </SelectContent>
         </Select>
 
-        <Select defaultValue="all" onValueChange={setFormat}>
+        <Select defaultValue="GIF" onValueChange={setFormatVal}>
           <SelectTrigger className="w-[150px] h-[45px] bg-custom-gray-500 rounded-2xl">
             <SelectValue placeholder="포맷 선택" />
           </SelectTrigger>

--- a/components/resource/graphic-info.tsx
+++ b/components/resource/graphic-info.tsx
@@ -1,0 +1,61 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useCallback, useContext, useEffect, useState } from 'react';
+import { GraphicRadioGroup } from './graphic-radio-group';
+import { GraphicContext } from './graphics';
+
+export function GraphicInfo() {
+  const [format, setFormat] = useState('all');
+  const [order, setOrder] = useState('recent');
+  const graphicContext = useContext(GraphicContext);
+  const handleGetGraphics = graphicContext?.handleGetGraphics;
+
+  const handleValueChange = useCallback(() => {
+    console.log('선택된 값:', order, format); // 선택된 값을 콘솔에 출력
+
+    if (handleGetGraphics) {
+      // const query = {};
+      // TODO: 정렬 기능 추가 필요
+      // await handleGetGraphics(query);
+    }
+  }, [order, format, handleGetGraphics]);
+
+  useEffect(() => {
+    void handleValueChange();
+  }, [order, format, handleValueChange]);
+
+  return (
+    <div className="flex items-center gap-8">
+      <GraphicRadioGroup />
+      <div className="flex gap-2">
+        <Select defaultValue="recent" onValueChange={setOrder}>
+          <SelectTrigger className="w-[150px] h-[45px] bg-custom-gray-500 rounded-2xl">
+            <SelectValue placeholder="정렬 기준 선택" />
+          </SelectTrigger>
+          <SelectContent className="bg-custom-gray-400 rounded-2xl ">
+            <SelectItem value="recent">최근 등록 순</SelectItem>
+            <SelectItem value="oldest">오래된 순</SelectItem>
+            <SelectItem value="korean-alphabet">가나다 순</SelectItem>
+            <SelectItem value="alphabetical">알파벳 순</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select defaultValue="all" onValueChange={setFormat}>
+          <SelectTrigger className="w-[150px] h-[45px] bg-custom-gray-500 rounded-2xl">
+            <SelectValue placeholder="포맷 선택" />
+          </SelectTrigger>
+          <SelectContent className="bg-custom-gray-400 rounded-2xl ">
+            <SelectItem value="all">포맷 전체</SelectItem>
+            <SelectItem value="GIF">GIF</SelectItem>
+            <SelectItem value="Lottie">Lottie</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/components/resource/graphic-radio-group.tsx
+++ b/components/resource/graphic-radio-group.tsx
@@ -1,91 +1,45 @@
 'use client';
 
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useForm } from 'react-hook-form';
-import { z } from 'zod';
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form';
+import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { GraphicContext } from './graphics';
 
-const FormSchema = z.object({
-  category: z.enum(['Message', 'Sticker', 'Challenge'], {
-    required_error: 'You need to select a category type.',
-  }),
-});
-
 export function GraphicRadioGroup() {
+  const [categoryVal, setCategoryVal] = useState('Message');
   const { setCategory, graphicInfo } = useContext(GraphicContext)!;
 
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
-  });
-
-  const { watch } = form;
-  const selected = watch('category') || 'Message';
-
   useEffect(() => {
-    setCategory && setCategory(selected);
-  }, [selected, setCategory]);
+    setCategory(categoryVal);
+  }, [categoryVal, setCategory]);
 
   return (
-    <Form {...form}>
-      <form className="w-2/3 space-y-6">
-        <FormField
-          control={form.control}
-          name="category"
-          render={({ field }) => (
-            <FormItem className="space-y-3">
-              <FormControl>
-                <RadioGroup
-                  onValueChange={(value) => field.onChange(value)}
-                  defaultValue={field.value}
-                  className="flex w-fit space-y-1 dark:bg-custom-gray-500 rounded-2xl"
-                >
-                  <FormItem
-                    className={`flex items-center rounded-2xl ${selected === 'Message' ? 'dark:bg-white dark:text-black' : 'dark:bg-custom-gray-500'}`}
-                  >
-                    <FormControl>
-                      <RadioGroupItem className="hidden" value="Message" />
-                    </FormControl>
-                    <FormLabel className="!mt-0 px-6 py-4 font-normal cursor-pointer">
-                      말풍선 {graphicInfo?.messageLength || 0}
-                    </FormLabel>
-                  </FormItem>
-                  <FormItem
-                    className={`flex items-center !mt-0 rounded-2xl ${selected === 'Sticker' ? 'dark:bg-white dark:text-black' : 'dark:bg-custom-gray-500'}`}
-                  >
-                    <FormControl>
-                      <RadioGroupItem className="hidden" value="Sticker" />
-                    </FormControl>
-                    <FormLabel className="!mt-0 px-6 py-4 font-normal cursor-pointer">
-                      스티커 {graphicInfo?.stickerLength || 0}
-                    </FormLabel>
-                  </FormItem>
-                  <FormItem
-                    className={`flex items-center !mt-0 rounded-2xl ${selected === 'Challenge' ? 'dark:bg-white dark:text-black' : 'dark:bg-custom-gray-500'}`}
-                  >
-                    <FormControl>
-                      <RadioGroupItem className="hidden" value="Challenge" />
-                    </FormControl>
-                    <FormLabel className="!mt-0 px-6 py-4 font-normal cursor-pointer">
-                      챌린지 {graphicInfo?.challengeLength || 0}
-                    </FormLabel>
-                  </FormItem>
-                </RadioGroup>
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-      </form>
-    </Form>
+    <RadioGroup
+      onValueChange={setCategoryVal}
+      defaultValue="Message"
+      className="flex w-fit space-y-1 dark:bg-custom-gray-500 rounded-2xl"
+    >
+      <RadioGroupItem className="hidden" value="Message" id="message" />
+      <Label
+        htmlFor="message"
+        className={`!mt-0 px-6 py-4 font-normal cursor-pointer rounded-2xl ${categoryVal === 'Message' ? 'dark:bg-white dark:text-black' : 'dark:bg-custom-gray-500'}`}
+      >
+        말풍선 {graphicInfo?.messageLength || 0}
+      </Label>
+      <RadioGroupItem className="hidden" value="Sticker" id="sticker" />
+      <Label
+        htmlFor="sticker"
+        className={`!mt-0 px-6 py-4 font-normal cursor-pointer rounded-2xl ${categoryVal === 'Sticker' ? 'dark:bg-white dark:text-black' : 'dark:bg-custom-gray-500'}`}
+      >
+        스티커 {graphicInfo?.stickerLength || 0}
+      </Label>
+      <RadioGroupItem className="hidden" value="Challenge" id="challenge" />
+      <Label
+        htmlFor="challenge"
+        className={`!mt-0 px-6 py-4 font-normal cursor-pointer rounded-2xl ${categoryVal === 'Challenge' ? 'dark:bg-white dark:text-black' : 'dark:bg-custom-gray-500'}`}
+      >
+        챌린지 {graphicInfo?.challengeLength || 0}
+      </Label>
+    </RadioGroup>
   );
 }

--- a/components/resource/graphic-upload.tsx
+++ b/components/resource/graphic-upload.tsx
@@ -44,7 +44,7 @@ export function GraphicUpload({
   const [errors, setErrors] = useState<GraphicFieldErrors>();
   const [previewUrl, setPreviewUrl] = useState('');
   const [lottieData, setLottieData] = useState<unknown>(null);
-  const { category, handleGetGraphics } = useContext(GraphicContext)!;
+  const { handleGetGraphics } = useContext(GraphicContext)!;
 
   const handleUpload = (formData: FormData) => {
     const file = formData.get('file');
@@ -75,7 +75,7 @@ export function GraphicUpload({
         void toast.promise(uploadGraphic(formData), {
           loading: '등록 중입니다.',
           success: () => {
-            void handleGetGraphics({ category });
+            void handleGetGraphics();
             if (submitType === 'done') onOpenChange(false);
             else setUploadList([...uploadList, formData]);
 

--- a/components/resource/graphics.tsx
+++ b/components/resource/graphics.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Avatar, AvatarImage } from '@/components/ui/avatar';
 import { DataTable } from '@/components/ui/data-table/data-table';
 import type { Graphic, GraphicContextType, GraphicsInfo } from '@/types';
 import type { ColumnDef } from '@tanstack/react-table';
@@ -9,6 +9,7 @@ import { createContext, useCallback, useEffect, useState } from 'react';
 import { getGraphics } from '@/apis';
 import { Checkbox } from '../ui/checkbox';
 import LottieAnimation from './lottie-animation';
+import { Loading } from '../common/loading';
 
 export const GraphicContext = createContext<GraphicContextType | undefined>(
   undefined,
@@ -44,7 +45,7 @@ export const Graphics = () => {
         return type === 'GIF' ? (
           <Avatar className="h-9 w-9">
             <AvatarImage src={row.getValue('url')} alt={row.getValue('name')} />
-            <AvatarFallback>{row.getValue('name')}</AvatarFallback>
+            <Loading />
           </Avatar>
         ) : type === 'Lottie' ? (
           <LottieAnimation url={row.getValue('url')} />

--- a/components/resource/graphics.tsx
+++ b/components/resource/graphics.tsx
@@ -2,15 +2,10 @@
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { DataTable } from '@/components/ui/data-table/data-table';
-import type {
-  Graphic,
-  GraphicContextType,
-  GraphicParams,
-  GraphicsInfo,
-} from '@/types';
+import type { Graphic, GraphicContextType, GraphicsInfo } from '@/types';
 import type { ColumnDef } from '@tanstack/react-table';
 import { DataTableColumnHeader } from '../ui/data-table/data-table-column-header';
-import { createContext, useEffect, useState } from 'react';
+import { createContext, useCallback, useEffect, useState } from 'react';
 import { getGraphics } from '@/apis';
 import { Checkbox } from '../ui/checkbox';
 import LottieAnimation from './lottie-animation';
@@ -22,11 +17,18 @@ export const GraphicContext = createContext<GraphicContextType | undefined>(
 export const Graphics = () => {
   const [graphics, setGraphics] = useState<Graphic[]>([]);
   const [category, setCategory] = useState('');
+  const [order, setOrder] = useState('');
+  const [format, setFormat] = useState('');
 
-  const handleGetGraphics = async (data?: GraphicParams) => {
-    const graphics = await getGraphics(data);
-    setGraphics(graphics);
-  };
+  const handleGetGraphics = useCallback(async () => {
+    const params = {
+      category,
+      order,
+      graphicType: format,
+    };
+    const data = await getGraphics(params);
+    setGraphics(data);
+  }, [category, order, format]);
 
   const columns: ColumnDef<Graphic>[] = [
     {
@@ -91,51 +93,52 @@ export const Graphics = () => {
     challengeLength: 0,
   });
 
+  // 각 카테고리별 개수 계산용 조회
+  // TODO: 개선 필요해 보임
   const handleGetGraphicsAll = async () => {
-    try {
-      const allGraphics = await getGraphics();
+    const allGraphics = await getGraphics();
 
-      // 각 카테고리별 개수를 계산
-      const categoryCounts = allGraphics.reduce(
-        (acc, graphic) => {
-          switch (graphic.category) {
-            case 'Message':
-              acc.messageLength += 1;
-              break;
-            case 'Sticker':
-              acc.stickerLength += 1;
-              break;
-            case 'Challenge':
-              acc.challengeLength += 1;
-              break;
-            default:
-              break;
-          }
-          return acc;
-        },
-        { messageLength: 0, stickerLength: 0, challengeLength: 0 },
-      );
+    const categoryCounts = allGraphics.reduce(
+      (acc, graphic) => {
+        switch (graphic.category) {
+          case 'Message':
+            acc.messageLength += 1;
+            break;
+          case 'Sticker':
+            acc.stickerLength += 1;
+            break;
+          case 'Challenge':
+            acc.challengeLength += 1;
+            break;
+          default:
+            break;
+        }
+        return acc;
+      },
+      { messageLength: 0, stickerLength: 0, challengeLength: 0 },
+    );
 
-      // 상태 업데이트
-
-      setGraphicInfo(categoryCounts);
-    } catch (error) {
-      console.error('Failed to fetch graphics:', error);
-    }
+    setGraphicInfo(categoryCounts);
   };
   useEffect(() => {
     void handleGetGraphicsAll();
   }, [graphics]);
 
   useEffect(() => {
-    if (category) void handleGetGraphics({ category });
-  }, [category]);
+    if (category) void handleGetGraphics();
+  }, [category, order, format, handleGetGraphics]);
 
   return (
     <>
       <div className="flex items-center justify-between space-y-2">
         <GraphicContext.Provider
-          value={{ handleGetGraphics, category, setCategory, graphicInfo }}
+          value={{
+            handleGetGraphics,
+            setCategory,
+            setOrder,
+            setFormat,
+            graphicInfo,
+          }}
         >
           <DataTable type="graphic" columns={columns} data={graphics} />
         </GraphicContext.Provider>

--- a/components/resource/lottie-animation.tsx
+++ b/components/resource/lottie-animation.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import Lottie from 'react-lottie-player';
+import { Loading } from '../common/loading';
 
 interface LottieAnimationProps {
   url?: string;
@@ -40,7 +41,7 @@ const LottieAnimation = ({
   }, [url, data]);
 
   if (!animationData) {
-    return <div>Loading...</div>;
+    return <Loading />;
   }
 
   const defaultOptions = {

--- a/components/ui/data-table/data-editor.tsx
+++ b/components/ui/data-table/data-editor.tsx
@@ -44,7 +44,6 @@ export function DataEditor<TData>({
   const [isModified, setIsModified] = useState(false); // 수정 여부 상태 변수 추가
 
   const graphicContext = useContext(GraphicContext);
-  const category = graphicContext?.category || '';
   const handleGetGraphics = graphicContext?.handleGetGraphics;
 
   const breedContext = useContext(BreedContext);
@@ -95,7 +94,7 @@ export function DataEditor<TData>({
 
   const execCloseCallback = (type?: string) => {
     const closeCallbacks = {
-      graphic: () => handleGetGraphics && handleGetGraphics({ category }),
+      graphic: () => handleGetGraphics && handleGetGraphics(),
       breed: () => handleGetBreeds && handleGetBreeds(),
     };
     const isValidType = (
@@ -118,7 +117,7 @@ export function DataEditor<TData>({
       // 데이터 타입 별 팝업 close 시 수행할 callback
       // 수정이 일어난 경우에만 실행
       const closeCallbacks = {
-        graphic: () => handleGetGraphics && handleGetGraphics({ category }),
+        graphic: () => handleGetGraphics && handleGetGraphics(),
         breed: () => handleGetBreeds && handleGetBreeds(),
       };
 
@@ -128,15 +127,7 @@ export function DataEditor<TData>({
       setIsModified(false); // 재조회 후 수정 여부 상태 초기화
     }
     prevValueRef.current = open;
-  }, [
-    open,
-    isModified,
-    type,
-    handleGetGraphics,
-    handleGetBreeds,
-    category,
-    table,
-  ]);
+  }, [open, isModified, type, handleGetGraphics, handleGetBreeds, table]);
 
   return (
     <div className="flex ml-16">

--- a/components/ui/data-table/data-editor.tsx
+++ b/components/ui/data-table/data-editor.tsx
@@ -13,7 +13,7 @@ import {
 } from '../carousel';
 import { GraphicUpdate } from '@/components/resource/graphic-update';
 import { GraphicContext } from '@/components/resource/graphics';
-import type { EditorDataType, GraphicData } from '@/types';
+import type { BreedData, EditorDataType, GraphicData } from '@/types';
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -27,6 +27,7 @@ import { Button } from 'components/ui/button';
 import toast from 'react-hot-toast';
 import { deleteGraphic } from '@/apis';
 import { BreedContext } from '@/components/resource/dogs';
+import { BreedUpdate } from '@/components/resource/breed-update';
 
 interface DataTableEditorProps<TData> {
   type: EditorDataType;
@@ -147,12 +148,17 @@ export function DataEditor<TData>({
             <CarouselContent>
               {selectedItems.map((item) => (
                 <CarouselItem key={item.id}>
-                  {type === 'graphic' && (
+                  {type === 'graphic' ? (
                     <GraphicUpdate
                       selectedItem={item.original as GraphicData}
                       onEditComplete={() => setIsModified(true)} // 수정 완료 여부 체크
                     />
-                  )}
+                  ) : type === 'breed' ? (
+                    <BreedUpdate
+                      selectedItem={item.original as BreedData}
+                      onEditComplete={() => setIsModified(true)} // 수정 완료 여부 체크
+                    />
+                  ) : null}
                 </CarouselItem>
               ))}
             </CarouselContent>

--- a/components/ui/data-table/data-editor.tsx
+++ b/components/ui/data-table/data-editor.tsx
@@ -26,6 +26,7 @@ import {
 import { Button } from 'components/ui/button';
 import toast from 'react-hot-toast';
 import { deleteGraphic } from '@/apis';
+import { BreedContext } from '@/components/resource/dogs';
 
 interface DataTableEditorProps<TData> {
   type: EditorDataType;
@@ -40,7 +41,13 @@ export function DataEditor<TData>({
   const [alertOpen, setAlertOpen] = useState(false);
   const [selectedItems, setSelectedItems] = useState<Row<TData>[]>([]);
   const [isModified, setIsModified] = useState(false); // 수정 여부 상태 변수 추가
-  const { category, handleGetGraphics } = useContext(GraphicContext)!;
+
+  const graphicContext = useContext(GraphicContext);
+  const category = graphicContext?.category || '';
+  const handleGetGraphics = graphicContext?.handleGetGraphics;
+
+  const breedContext = useContext(BreedContext);
+  const handleGetBreeds = breedContext?.handleGetBreeds;
   const prevValueRef = useRef(false);
 
   const handleOpen = () => {
@@ -70,7 +77,8 @@ export function DataEditor<TData>({
 
   const execCloseCallback = (type?: string) => {
     const closeCallbacks = {
-      graphic: () => handleGetGraphics({ category }),
+      graphic: () => handleGetGraphics && handleGetGraphics({ category }),
+      breed: () => handleGetBreeds && handleGetBreeds(),
     };
     const isValidType = (
       type?: string,
@@ -92,7 +100,8 @@ export function DataEditor<TData>({
       // 데이터 타입 별 팝업 close 시 수행할 callback
       // 수정이 일어난 경우에만 실행
       const closeCallbacks = {
-        graphic: () => handleGetGraphics({ category }),
+        graphic: () => handleGetGraphics && handleGetGraphics({ category }),
+        breed: () => handleGetBreeds && handleGetBreeds(),
       };
 
       const callback = type && closeCallbacks[type];
@@ -101,7 +110,15 @@ export function DataEditor<TData>({
       setIsModified(false); // 재조회 후 수정 여부 상태 초기화
     }
     prevValueRef.current = open;
-  }, [open, isModified, type, handleGetGraphics, category, table]);
+  }, [
+    open,
+    isModified,
+    type,
+    handleGetGraphics,
+    handleGetBreeds,
+    category,
+    table,
+  ]);
 
   return (
     <div className="flex ml-16">

--- a/components/ui/data-table/data-editor.tsx
+++ b/components/ui/data-table/data-editor.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { Button } from 'components/ui/button';
 import toast from 'react-hot-toast';
-import { deleteGraphic } from '@/apis';
+import { deleteBreeds, deleteGraphics } from '@/apis';
 import { BreedContext } from '@/components/resource/dogs';
 import { BreedUpdate } from '@/components/resource/breed-update';
 
@@ -56,14 +56,31 @@ export function DataEditor<TData>({
   };
 
   const handleDelete = () => {
-    if (type === 'graphic') {
+    if (type === 'breed') {
+      const items = table
+        .getFilteredSelectedRowModel()
+        .rows.map((item) => item.original as BreedData);
+      const ids = items.map((item) => item.id);
+
+      if (ids) {
+        void toast.promise(deleteBreeds(ids), {
+          loading: '삭제 중입니다.',
+          success: () => {
+            setAlertOpen(false);
+            execCloseCallback(type);
+            return <b>삭제되었습니다!</b>;
+          },
+          error: <b>견종 삭제에 실패하였습니다.</b>,
+        });
+      }
+    } else if (type === 'graphic') {
       const items = table
         .getFilteredSelectedRowModel()
         .rows.map((item) => item.original as GraphicData);
       const ids = items.map((item) => item.id);
 
       if (ids) {
-        void toast.promise(deleteGraphic(ids), {
+        void toast.promise(deleteGraphics(ids), {
           loading: '삭제 중입니다.',
           success: () => {
             setAlertOpen(false);

--- a/components/ui/data-table/data-table-toolbar.tsx
+++ b/components/ui/data-table/data-table-toolbar.tsx
@@ -6,9 +6,9 @@ import { DataEditor } from './data-editor';
 import { GraphicUploadPopup } from '@/components/resource/graphic-upload-popup';
 import { useState } from 'react';
 import type { EditorDataType } from '@/types';
-import { GraphicRadioGroup } from '@/components/resource/graphic-radio-group';
 import { BreedUploadPopup } from '@/components/resource/breed-upload-popup';
 import { BreedInfo } from '@/components/resource/breed-info';
+import { GraphicInfo } from '@/components/resource/graphic-info';
 
 interface DataTableToolbarProps<TData> {
   type: EditorDataType;
@@ -36,7 +36,7 @@ export function DataTableToolbar<TData>({
   return (
     <div className="flex items-center justify-between mb-5">
       {type === 'breed' && <BreedInfo table={table} />}
-      {type === 'graphic' && <GraphicRadioGroup />}
+      {type === 'graphic' && <GraphicInfo />}
 
       <div className="flex flex-1 justify-end items-center gap-4 space-x-2">
         <Input

--- a/components/ui/data-table/data-table-toolbar.tsx
+++ b/components/ui/data-table/data-table-toolbar.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import type { EditorDataType } from '@/types';
 import { GraphicRadioGroup } from '@/components/resource/graphic-radio-group';
 import { BreedUploadPopup } from '@/components/resource/breed-upload-popup';
+import { BreedInfo } from '@/components/resource/breed-info';
 
 interface DataTableToolbarProps<TData> {
   type: EditorDataType;
@@ -33,7 +34,8 @@ export function DataTableToolbar<TData>({
   const placeholder = getPlaceholder(type);
 
   return (
-    <div className="flex items-center justify-between mb-8">
+    <div className="flex items-center justify-between mb-5">
+      {type === 'breed' && <BreedInfo table={table} />}
       {type === 'graphic' && <GraphicRadioGroup />}
 
       <div className="flex flex-1 justify-end items-center gap-4 space-x-2">

--- a/components/ui/data-table/data-table-toolbar.tsx
+++ b/components/ui/data-table/data-table-toolbar.tsx
@@ -7,6 +7,7 @@ import { GraphicUploadPopup } from '@/components/resource/graphic-upload-popup';
 import { useState } from 'react';
 import type { EditorDataType } from '@/types';
 import { GraphicRadioGroup } from '@/components/resource/graphic-radio-group';
+import { BreedUploadPopup } from '@/components/resource/breed-upload-popup';
 
 interface DataTableToolbarProps<TData> {
   type: EditorDataType;
@@ -14,7 +15,7 @@ interface DataTableToolbarProps<TData> {
 }
 
 const placeholderList = {
-  breeds: '견종 이름 검색',
+  breed: '견종 이름 검색',
   graphic: '파일명 검색',
 };
 
@@ -26,7 +27,7 @@ export function DataTableToolbar<TData>({
   const isAnyItemSelected = table.getFilteredSelectedRowModel().rows.length > 0;
 
   const getPlaceholder = (type?: keyof typeof placeholderList): string => {
-    return type ? placeholderList[type] || '' : '검색';
+    return type ? placeholderList[type] || '검색' : '검색';
   };
 
   const placeholder = getPlaceholder(type);
@@ -45,6 +46,8 @@ export function DataTableToolbar<TData>({
         />
         {type === 'graphic' ? (
           <GraphicUploadPopup isOpen={isOpen} onOpenChange={setIsOpen} />
+        ) : type === 'breed' ? (
+          <BreedUploadPopup isOpen={isOpen} onOpenChange={setIsOpen} />
         ) : null}
       </div>
       {isAnyItemSelected && <DataEditor type={type} table={table} />}

--- a/components/ui/data-table/data-table.tsx
+++ b/components/ui/data-table/data-table.tsx
@@ -120,7 +120,7 @@ export function DataTable<TData, TValue>({
                   colSpan={columns.length}
                   className="h-24 text-center"
                 >
-                  No results.
+                  데이터 없음
                 </TableCell>
               </TableRow>
             )}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -86,7 +86,8 @@ const SelectContent = React.forwardRef<
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
         className={cn(
-          'p-1',
+          'p-0',
+          'divide-y divide-custom-gray-300 ',
           position === 'popper' &&
             'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]',
         )}
@@ -118,12 +119,12 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-4 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center py-4 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="absolute left-3 flex h-3.5 w-3.5 items-center justify-center">
       <SelectPrimitive.ItemIndicator>
         <Check className="h-4 w-4" />
       </SelectPrimitive.ItemIndicator>

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,41 +1,45 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as TabsPrimitive from "@radix-ui/react-tabs"
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
 
-import { cn } from "lib/utils"
+import { cn } from 'lib/utils';
 
-const Tabs = TabsPrimitive.Root
+const Tabs = TabsPrimitive.Root;
 
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> & {
+    tabType: string;
+  }
+>(({ className, tabType, ...props }, ref) => (
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
-      className
+      `inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-custom-gray-300 ${tabType === 'menu' && 'bg-none!'}`,
+      className,
     )}
     {...props}
   />
-))
-TabsList.displayName = TabsPrimitive.List.displayName
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
 
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> & {
+    tabType: string;
+  }
+>(({ className, tabType, ...props }, ref) => (
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
-      className
+      `inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm ${tabType === 'menu' && 'text-5xl px-0 mr-8'}`,
+      className,
     )}
     {...props}
   />
-))
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
@@ -44,12 +48,12 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-      className
+      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      className,
     )}
     {...props}
   />
-))
-TabsContent.displayName = TabsPrimitive.Content.displayName
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -10,7 +10,7 @@ const Tabs = TabsPrimitive.Root;
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> & {
-    tabType: string;
+    tabType?: string;
   }
 >(({ className, tabType, ...props }, ref) => (
   <TabsPrimitive.List
@@ -27,7 +27,7 @@ TabsList.displayName = TabsPrimitive.List.displayName;
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> & {
-    tabType: string;
+    tabType?: string;
   }
 >(({ className, tabType, ...props }, ref) => (
   <TabsPrimitive.Trigger

--- a/lib/validators.tsx
+++ b/lib/validators.tsx
@@ -18,6 +18,21 @@ export const RegisterSchema = z.object({
   }),
 });
 
+export const BreedUploadSchema = z.object({
+  nameKR: z.string().min(1, {
+    message: '국문 이름을 입력해주세요.',
+  }),
+  nameEN: z.string().min(1, {
+    message: '영문 이름을 입력해주세요.',
+  }),
+  avatar: z
+    .instanceof(File)
+    .refine(
+      (file) => file instanceof File && file.size > 0,
+      '파일을 등록해주세요.',
+    ),
+});
+
 export const GraphicUploadSchema = z.object({
   category: z.string().min(1, {
     message: '카테고리를 선택해주세요.',

--- a/lib/validators.tsx
+++ b/lib/validators.tsx
@@ -48,6 +48,10 @@ export const GraphicUploadSchema = z.object({
     ),
 });
 
+export const BreedUpdateSchema = z.object({
+  nameKR: z.string().optional(),
+  nameEN: z.string().optional(),
+});
 export const GraphicUpdateSchema = z.object({
   category: z.string().min(1, '카테고리를 선택해주세요.'),
   name: z.string().optional(),

--- a/types/index.tsx
+++ b/types/index.tsx
@@ -21,7 +21,7 @@ export interface APIResponse<T> {
 
 export interface Breed {
   id: string;
-  name: string;
+  nameKR: string;
   nameEN: string;
   avatar: string;
 }
@@ -48,6 +48,13 @@ export interface GraphicData {
   type: 'GIF' | 'Lottie';
   url: string;
   id: string;
+}
+export interface BreedData {
+  id: string;
+  nameKR: string;
+  nameEN: string;
+  file: File;
+  avatar: string;
 }
 
 export interface BreedFieldErrors {

--- a/types/index.tsx
+++ b/types/index.tsx
@@ -73,9 +73,11 @@ export interface GraphicFieldErrors {
 export type EditorDataType = 'breed' | 'graphic' | undefined;
 
 export interface GraphicContextType {
-  handleGetGraphics: (data?: GraphicParams) => Promise<void>;
-  category: string;
+  handleGetGraphics: () => Promise<void>;
   setCategory: (category: string) => void;
+  setOrder: (order: string) => void;
+  setFormat: (format: string) => void;
+
   graphicInfo: {
     challengeLength: number;
     messageLength: number;
@@ -83,7 +85,7 @@ export interface GraphicContextType {
   };
 }
 export interface BreedContextType {
-  handleGetBreeds: (query?: GetBreedsQuery) => Promise<void>;
+  handleGetBreeds: (query?: GetBreedsParams) => Promise<void>;
 }
 
 export interface GraphicsInfo {
@@ -92,7 +94,7 @@ export interface GraphicsInfo {
   challengeLength: number;
 }
 
-export interface GetBreedsQuery {
+export interface GetBreedsParams {
   [key: string]: string | undefined;
   orderKey?: string;
   direction?: string;

--- a/types/index.tsx
+++ b/types/index.tsx
@@ -60,6 +60,7 @@ export interface GraphicFieldErrors {
   name?: string[];
   category?: string[];
   file?: string[];
+  type?: string[];
 }
 
 export type EditorDataType = 'breed' | 'graphic' | undefined;

--- a/types/index.tsx
+++ b/types/index.tsx
@@ -19,11 +19,6 @@ export interface APIResponse<T> {
   body: T;
 }
 
-// 견종 정보 리스트
-export interface BreedList {
-  [key: string]: Breed[];
-}
-
 export interface Breed {
   id: string;
   name: string;
@@ -55,14 +50,19 @@ export interface GraphicData {
   id: string;
 }
 
+export interface BreedFieldErrors {
+  nameKR?: string[];
+  nameEN?: string[];
+  file?: string[];
+}
+
 export interface GraphicFieldErrors {
   name?: string[];
   category?: string[];
   file?: string[];
-  type?: string[];
 }
 
-export type EditorDataType = 'graphic' | undefined;
+export type EditorDataType = 'breed' | 'graphic' | undefined;
 
 export interface GraphicContextType {
   handleGetGraphics: (data?: GraphicParams) => Promise<void>;
@@ -73,6 +73,9 @@ export interface GraphicContextType {
     messageLength: number;
     stickerLength: number;
   };
+}
+export interface BreedContextType {
+  handleGetBreeds: () => Promise<void>;
 }
 
 export interface GraphicsInfo {

--- a/types/index.tsx
+++ b/types/index.tsx
@@ -83,7 +83,7 @@ export interface GraphicContextType {
   };
 }
 export interface BreedContextType {
-  handleGetBreeds: () => Promise<void>;
+  handleGetBreeds: (query?: GetBreedsQuery) => Promise<void>;
 }
 
 export interface GraphicsInfo {

--- a/types/index.tsx
+++ b/types/index.tsx
@@ -91,3 +91,10 @@ export interface GraphicsInfo {
   stickerLength: number;
   challengeLength: number;
 }
+
+export interface GetBreedsQuery {
+  [key: string]: string | undefined;
+  orderKey?: string;
+  direction?: string;
+  cursoer?: string;
+}


### PR DESCRIPTION
## PR 제목

## 이슈 번호 및 링크카 있다면 알려주세요.

## 리뷰 요청 전 확인해주세요.

- [x] 원하는 기능을 구현했습니다.
- [x] 코드 컨벤션에 이상이 없는지 확인했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 추가된 패키지가 있다면 체크해주세요.

- [ ] 새로운 패키지를 추가했습니다.

## 변경 사항에 대해 간단히 설명 해주세요.
이미지 연속 등록/수정 및 삭제는 그래픽 이미지와 동일한 플로우

- 등록된 견종 정보 조회
<img width="1156" alt="image" src="https://github.com/user-attachments/assets/a6bd66c9-7198-4f27-843a-a2ae9609deb1">

- 견종 추가  
![견종 추가](https://github.com/user-attachments/assets/4a813d14-df23-4069-8241-ef75b759d1fb)  

- 견종 수정
![견종 수정](https://github.com/user-attachments/assets/f1178694-dcc5-4fd2-b549-8cc06a1ef4f9)

- 견종 삭제
![견종 삭제](https://github.com/user-attachments/assets/a0f014e1-b9c8-4009-b678-ab6b14137c24)


## 그래픽 정렬 및 필터
피그마 상의 정렬 방식은 비활성화 해두고 현재 API 기준 가능한 정렬 방식만 활성화

![그래픽 정렬](https://github.com/user-attachments/assets/babd2f3b-d805-4413-8bd1-83fd6c6a0615)

<img width="340" alt="스크린샷 2024-07-28 오전 10 09 21" src="https://github.com/user-attachments/assets/34528a37-1793-49fa-b43a-b41c8c5e8806">

<img width="215" alt="스크린샷 2024-07-28 오전 10 06 19" src="https://github.com/user-attachments/assets/023c71af-4b7a-4916-9173-c83b0dfc3e75">

