### PR TITLE
[POOP-154] 어드민 데이터 목록 페이지네이션 방식 변경

### DIFF
--- a/apis/index.ts
+++ b/apis/index.ts
@@ -57,9 +57,19 @@ export const getGraphics = async (params?: GraphicParams) => {
     const {
       result: { resultCode },
       body,
-    } = await GET<Graphic[]>(`/graphics${queryStr && '?' + queryStr}`);
+    } = await GET<pageResponse<Graphic>>(
+      `/graphics${queryStr && '?' + queryStr}`,
+    );
 
-    return resultCode < 500 ? body : [];
+    return resultCode < 500
+      ? body
+      : {
+          list: [],
+          took: 1,
+          page: 1,
+          total: 1,
+          totalPage: 11,
+        };
   } catch (error) {
     console.error(error);
     throw new Error('Failed to get graphics');

--- a/apis/index.ts
+++ b/apis/index.ts
@@ -1,11 +1,17 @@
 import { GET, PUT, POST, DELETE } from '@/server/axios';
-import type { Breed, GetBreedsParams, Graphic, GraphicParams } from '@/types';
+import type {
+  Breed,
+  GetBreedsParams,
+  Graphic,
+  GraphicParams,
+  pageResponse,
+} from '@/types';
 
 // parameter -> query 변환 함수 정의
 const toRecord = (
   params?: GraphicParams | GetBreedsParams,
-): Record<string, string> => {
-  const result: Record<string, string> = {};
+): Record<string | number, string> => {
+  const result: Record<string | number, string> = {};
   if (params) {
     for (const key in params) {
       if (
@@ -26,8 +32,17 @@ export const getBreeds = async (query?: GetBreedsParams) => {
     const {
       result: { resultCode },
       body,
-    } = await GET<Breed[]>(`/breeds?${queryStr}`);
-    return resultCode < 500 ? body : [];
+    } = await GET<pageResponse<Breed>>(`/breeds?${queryStr}`);
+
+    return resultCode < 500
+      ? body
+      : {
+          list: [],
+          took: 1,
+          page: 1,
+          total: 1,
+          totalPage: 11,
+        };
   } catch (error) {
     console.error(error);
     throw new Error('Failed to get breeds');

--- a/components/resource/graphic-info.tsx
+++ b/components/resource/graphic-info.tsx
@@ -10,7 +10,7 @@ import { GraphicRadioGroup } from './graphic-radio-group';
 import { GraphicContext } from './graphics';
 
 export function GraphicInfo() {
-  const [formatVal, setFormatVal] = useState('GIF');
+  const [formatVal, setFormatVal] = useState('all');
   const [orderVal, setOrderVal] = useState('DESC');
   const { setOrder, setFormat } = useContext(GraphicContext)!;
 
@@ -51,7 +51,7 @@ export function GraphicInfo() {
           </SelectContent>
         </Select>
 
-        <Select defaultValue="GIF" onValueChange={setFormatVal}>
+        <Select defaultValue="all" onValueChange={setFormatVal}>
           <SelectTrigger className="w-[150px] h-[45px] bg-custom-gray-500 rounded-2xl">
             <SelectValue placeholder="포맷 선택" />
           </SelectTrigger>

--- a/components/ui/data-table/data-table-pagination.tsx
+++ b/components/ui/data-table/data-table-pagination.tsx
@@ -1,3 +1,4 @@
+import type { pageInfo } from '@/types';
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -10,60 +11,117 @@ import { Button } from 'components/ui/button';
 
 interface DataTablePaginationProps<TData> {
   table: Table<TData>;
+  pageInfo?: pageInfo;
 }
 
 export function DataTablePagination<TData>({
   table,
+  pageInfo,
 }: DataTablePaginationProps<TData>) {
+  const curPage = pageInfo?.page || 1;
   return (
-    <div className="flex items-center justify-center space-x-2 m-16">
-      <Button
-        variant="ghost"
-        className="hidden h-[50px] w-[50px] rounded-2xl p-0 lg:flex bg-custom-gray-500"
-        onClick={() => table.setPageIndex(0)}
-        disabled={!table.getCanPreviousPage()}
-      >
-        <span className="sr-only">Go to first page</span>
-        <DoubleArrowLeftIcon className="h-4 w-4" />
-      </Button>
-      <Button
-        variant="ghost"
-        className="h-[50px] w-[50px] rounded-2xl p-0 bg-custom-gray-500"
-        onClick={() => table.previousPage()}
-        disabled={!table.getCanPreviousPage()}
-      >
-        <span className="sr-only">Go to previous page</span>
-        <ChevronLeftIcon className="h-4 w-4" />
-      </Button>
-      {Array.from({ length: table.getPageCount() }).map((_, idx) => (
-        <Button
-          key={idx}
-          variant="ghost"
-          className={`h-[50px] w-[50px] p-0 rounded-2xl ${idx !== table.getState().pagination.pageIndex && 'text-custom-gray-300'}`}
-          onClick={() => table.setPageIndex(idx)}
-        >
-          <span>{idx + 1}</span>
-        </Button>
-      ))}
+    <>
+      {pageInfo ? (
+        <div className="flex items-center justify-center space-x-2 m-16">
+          <Button
+            variant="ghost"
+            className="hidden h-[50px] w-[50px] rounded-2xl p-0 lg:flex bg-custom-gray-500"
+            onClick={() => pageInfo.setCurPage?.(1)}
+            disabled={pageInfo.page === 1}
+          >
+            <span className="sr-only">첫 페이지</span>
+            <DoubleArrowLeftIcon className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            className="h-[50px] w-[50px] rounded-2xl p-0 bg-custom-gray-500"
+            onClick={() => pageInfo.setCurPage?.(curPage - 1)}
+            disabled={pageInfo.page === 1}
+          >
+            <span className="sr-only">이전 페이지</span>
+            <ChevronLeftIcon className="h-4 w-4" />
+          </Button>
+          {Array.from({ length: pageInfo.totalPage }).map((_, idx) => (
+            <Button
+              key={idx}
+              variant="ghost"
+              className={`h-[50px] w-[50px] p-0 rounded-2xl ${idx + 1 !== curPage && 'text-custom-gray-300'}`}
+              onClick={() => pageInfo.setCurPage?.(idx + 1)}
+            >
+              <span>{idx + 1}</span>
+            </Button>
+          ))}
 
-      <Button
-        variant="ghost"
-        className="h-[50px] w-[50px] rounded-2xl p-0 bg-custom-gray-500"
-        onClick={() => table.nextPage()}
-        disabled={!table.getCanNextPage()}
-      >
-        <span className="sr-only">Go to next page</span>
-        <ChevronRightIcon className="h-4 w-4" />
-      </Button>
-      <Button
-        variant="ghost"
-        className="hidden h-[50px] w-[50px] rounded-2xl p-0 lg:flex bg-custom-gray-500"
-        onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-        disabled={!table.getCanNextPage()}
-      >
-        <span className="sr-only">Go to last page</span>
-        <DoubleArrowRightIcon className="h-4 w-4" />
-      </Button>
-    </div>
+          <Button
+            variant="ghost"
+            className="h-[50px] w-[50px] rounded-2xl p-0 bg-custom-gray-500"
+            onClick={() => pageInfo.setCurPage?.(curPage + 1)}
+            disabled={pageInfo.page === pageInfo.totalPage}
+          >
+            <span className="sr-only">다음 페이지</span>
+            <ChevronRightIcon className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            className="hidden h-[50px] w-[50px] rounded-2xl p-0 lg:flex bg-custom-gray-500"
+            onClick={() => pageInfo.setCurPage?.(pageInfo.totalPage)}
+            disabled={pageInfo.page === pageInfo.totalPage}
+          >
+            <span className="sr-only">마지막 페이지</span>
+            <DoubleArrowRightIcon className="h-4 w-4" />
+          </Button>
+        </div>
+      ) : (
+        <div className="flex items-center justify-center space-x-2 m-16">
+          <Button
+            variant="ghost"
+            className="hidden h-[50px] w-[50px] rounded-2xl p-0 lg:flex bg-custom-gray-500"
+            onClick={() => table.setPageIndex(0)}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <span className="sr-only">첫 페이지</span>
+            <DoubleArrowLeftIcon className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            className="h-[50px] w-[50px] rounded-2xl p-0 bg-custom-gray-500"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <span className="sr-only">이전 페이지</span>
+            <ChevronLeftIcon className="h-4 w-4" />
+          </Button>
+          {Array.from({ length: table.getPageCount() }).map((_, idx) => (
+            <Button
+              key={idx}
+              variant="ghost"
+              className={`h-[50px] w-[50px] p-0 rounded-2xl ${idx !== table.getState().pagination.pageIndex && 'text-custom-gray-300'}`}
+              onClick={() => table.setPageIndex(idx)}
+            >
+              <span>{idx + 1}</span>
+            </Button>
+          ))}
+
+          <Button
+            variant="ghost"
+            className="h-[50px] w-[50px] rounded-2xl p-0 bg-custom-gray-500"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            <span className="sr-only">다음 페이지</span>
+            <ChevronRightIcon className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            className="hidden h-[50px] w-[50px] rounded-2xl p-0 lg:flex bg-custom-gray-500"
+            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+            disabled={!table.getCanNextPage()}
+          >
+            <span className="sr-only">마지막 페이지</span>
+            <DoubleArrowRightIcon className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+    </>
   );
 }

--- a/components/ui/data-table/data-table.tsx
+++ b/components/ui/data-table/data-table.tsx
@@ -28,17 +28,19 @@ import {
 import { DataTablePagination } from 'components/ui/data-table/data-table-pagination';
 import { DataTableToolbar } from 'components/ui/data-table/data-table-toolbar';
 import { useEffect } from 'react';
-import type { EditorDataType } from '@/types';
+import type { EditorDataType, pageInfo } from '@/types';
 interface DataTableProps<TData, TValue> {
   type?: EditorDataType;
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
+  pageInfo?: pageInfo;
 }
 
 export function DataTable<TData, TValue>({
   type,
   columns,
   data,
+  pageInfo,
 }: DataTableProps<TData, TValue>) {
   const [rowSelection, setRowSelection] = React.useState({});
   const [columnVisibility, setColumnVisibility] =
@@ -127,7 +129,7 @@ export function DataTable<TData, TValue>({
           </TableBody>
         </Table>
       </div>
-      <DataTablePagination table={table} />
+      <DataTablePagination table={table} pageInfo={pageInfo} />
     </div>
   );
 }

--- a/types/index.tsx
+++ b/types/index.tsx
@@ -46,10 +46,11 @@ export interface Graphic {
 }
 
 export interface GraphicParams {
-  [key: string]: string | undefined;
+  [key: string]: string | number | undefined;
   graphicType?: string;
   category: string;
   string?: string;
+  page?: number;
 }
 
 export interface GraphicData {

--- a/types/index.tsx
+++ b/types/index.tsx
@@ -19,6 +19,17 @@ export interface APIResponse<T> {
   body: T;
 }
 
+export type pageResponse<T> = {
+  list: T[];
+} & pageInfo;
+
+export type pageInfo = {
+  page: number;
+  took: number;
+  total: number;
+  totalPage: number;
+  setCurPage?: (page: number) => void;
+};
 export interface Breed {
   id: string;
   nameKR: string;
@@ -95,8 +106,9 @@ export interface GraphicsInfo {
 }
 
 export interface GetBreedsParams {
-  [key: string]: string | undefined;
+  [key: string]: string | number | undefined;
   orderKey?: string;
   direction?: string;
   cursoer?: string;
+  page?: number;
 }


### PR DESCRIPTION
## PR 제목
[POOP-154] 어드민 데이터 목록 페이지네이션 방식 변경

## 이슈 번호 및 링크카 있다면 알려주세요.
<a href="https://www.notion.so/raymondanything/Poop-66257a641512433ebcec7270dbf7a4be?p=a18150af0ecd4064a12021896dc682dc&pm=s">POOP-15 Notion</a>

## 리뷰 요청 전 확인해주세요.

- [x] 원하는 기능을 구현했습니다.
- [x] 코드 컨벤션에 이상이 없는지 확인했습니다.
- [x] 불필요한 코드를 제거했습니다.

## 추가된 패키지가 있다면 체크해주세요.

- [ ] 새로운 패키지를 추가했습니다.


## 변경 사항에 대해 간단히 설명 해주세요.

기존 견종정보/그래픽 조회 시 한번에 모든 리스트를 받은 후 tanstack 라이브러리의 페이지네이션 처리 방식
-> 페이지 별 API 호출 방식

두 방식 모두 대응할 수 있도록 페이지네이션 분기처리

변경사항으로 인한 추가 작업 필요사항:
그래픽 조회의 경우 응답 형식 변경으로 인해 각 카테고리 별 이미지 개수 파악 불가